### PR TITLE
Add support for specifying date range in getContributionCalendar

### DIFF
--- a/contributions.ts
+++ b/contributions.ts
@@ -26,8 +26,8 @@ const isValidContributionLevelName = (
 const getContributionCalendar = async (
   userName: string,
   token: string,
-  from: string|null,
-  to: string|null,
+  from: string | null,
+  to: string | null,
 ) => {
   if (!userName || !token) {
     throw new Error("Missing required arguments");
@@ -52,7 +52,7 @@ const getContributionCalendar = async (
    }
  }
  `;
-  const variables = JSON.stringify({userName, from, to});
+  const variables = JSON.stringify({ userName, from, to });
 
   const json = { query, variables };
   const url = "https://api.github.com/graphql";
@@ -324,14 +324,14 @@ const contributionsToSvg = (
 const getContributions = async (
   userName: string,
   token: string,
-  from: string|null,
-  to: string|null
+  from: string | null,
+  to: string | null,
 ) => {
   const { contributions, totalContributions } = await getContributionCalendar(
     userName,
     token,
     from,
-    to
+    to,
   );
 
   const maxContributionDay = getMaxContributionDay(contributions);

--- a/contributions.ts
+++ b/contributions.ts
@@ -26,15 +26,17 @@ const isValidContributionLevelName = (
 const getContributionCalendar = async (
   userName: string,
   token: string,
+  from: string|null,
+  to: string|null,
 ) => {
   if (!userName || !token) {
     throw new Error("Missing required arguments");
   }
 
   const query = `
- query($userName:String!) {
+ query($userName:String! $from:DateTime $to:DateTime) {
    user(login: $userName){
-     contributionsCollection {
+     contributionsCollection(from: $from, to: $to) {
        contributionCalendar {
          totalContributions
          weeks {
@@ -50,11 +52,7 @@ const getContributionCalendar = async (
    }
  }
  `;
-  const variables = `
- {
-   "userName": "${userName}"
- }
- `;
+  const variables = JSON.stringify({userName, from, to});
 
   const json = { query, variables };
   const url = "https://api.github.com/graphql";
@@ -326,10 +324,14 @@ const contributionsToSvg = (
 const getContributions = async (
   userName: string,
   token: string,
+  from: string|null,
+  to: string|null
 ) => {
   const { contributions, totalContributions } = await getContributionCalendar(
     userName,
     token,
+    from,
+    to
   );
 
   const maxContributionDay = getMaxContributionDay(contributions);
@@ -405,4 +407,5 @@ export {
   moreContributionDay,
   totalMsg,
 };
+
 export type { ContributionDay, ContributionLevelName };

--- a/server.ts
+++ b/server.ts
@@ -31,9 +31,16 @@ async function handleRequest(request: Request) {
   const username = paths[1].replace(/\..*$/, "");
   const ext = getPathExtension(request);
 
+  const toYmd = searchParams.get("to") ?? null;
+  const fromYmd = searchParams.get("from") ?? null;
+  const from = fromYmd ? new Date(fromYmd).toISOString() : null;
+  const to = toYmd ? new Date(toYmd).toISOString() : null;
+
   const contributions = await getContributions(
     username,
     env.require("GH_READ_USER_TOKEN"),
+    from,
+    to
   );
 
   const scheme = searchParams.get("scheme") ?? "github";
@@ -88,6 +95,8 @@ async function handleRequest(request: Request) {
     " - frame=[color]      : use the color as a frame of image (svg)",
     " - bg=[color]         : use the color as a background of image (svg)",
     " - font-color=[color] : use the color as a font color (svg)",
+    " - from=[yyyy-mm-dd]  : get contributions from the date (term/text/svg/json)",
+    " - to=[yyyy-mm-dd]    : get contributions to the date (term/text/svg/json)",
     "",
     "Color parameters allows hex color string without # like '123abc'.",
   ].join("\n");

--- a/server.ts
+++ b/server.ts
@@ -40,7 +40,7 @@ async function handleRequest(request: Request) {
     username,
     env.require("GH_READ_USER_TOKEN"),
     from,
-    to
+    to,
   );
 
   const scheme = searchParams.get("scheme") ?? "github";


### PR DESCRIPTION
added support for receiving `from` and `to` parameters to be passed to GraphQL


## no parameter

![image](https://github.com/kawarimidoll/deno-github-contributions-api/assets/4104038/c2f6fdd3-8cf0-4f2c-9b12-06dc08f39444)

## to parameter

`to=2023-06-30`

![image](https://github.com/kawarimidoll/deno-github-contributions-api/assets/4104038/380f0d82-94ec-4335-9fb1-1a58bdd3bd80)
